### PR TITLE
Strictness mode follow-up

### DIFF
--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -129,7 +129,7 @@ Notes:
 
 **Solution:** See [`Gson` class documentation](https://www.javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/Gson.html) section "Lenient JSON handling"
 
-Note: Even in non-lenient mode Gson deviates slightly from the JSON specification, see [`JsonReader.setLenient`](https://www.javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/stream/JsonReader.html#setLenient(boolean)) for more details.
+Note: Even in non-lenient mode Gson deviates slightly from the JSON specification, see [`JsonReader.setStrictness`](https://www.javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/stream/JsonReader.html#setStrictness(Strictness)) for more details.
 
 ## `IllegalStateException`: "Expected ... but was ..."
 

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -1194,7 +1194,7 @@ public final class Gson {
    * <p>Unlike the other {@code fromJson} methods, no exception is thrown if the JSON data has
    * multiple top-level JSON elements, or if there is trailing data.
    *
-   * <p>he JSON data is parsed in {@linkplain JsonReader#setStrictness(Strictness) lenient mode},
+   * <p>The JSON data is parsed in {@linkplain JsonReader#setStrictness(Strictness) lenient mode},
    * regardless of the strictness setting of the provided reader. The strictness setting
    * of the reader is restored once this method returns.
    *

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -106,12 +106,13 @@ import java.util.concurrent.atomic.AtomicLongArray;
  * for a more complete set of examples.</p>
  *
  * <h2>Lenient JSON handling</h2>
- * For legacy reasons most of the {@code Gson} methods allow JSON data which does not
+ * For legacy reasons most of the {@code Gson} methods by default allow JSON data which does not
  * comply with the JSON specification, even when the strictness {@link Strictness#DEFAULT}
  * is used. To restrict a {@code Gson} instance from parsing JSON that
- * does not comply with the JSON specification, {@linkplain Strictness#STRICT strict} mode should be used.
- * Alternatively, if you do not want to use {@linkplain Strictness#STRICT strict} mode,
- * the following workarounds can be used:
+ * does not comply with the JSON specification, {@link Strictness#STRICT} mode should be used.
+ *
+ * <p>For older Gson versions which don't have the {@link Strictness} mode API the following
+ * workarounds can be used:
  *
  * <h3>Serialization</h3>
  * <ol>

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -521,17 +521,16 @@ public final class GsonBuilder {
   }
 
   /**
-   * Set the strictness of this builder to the provided parameter.
+   * Sets the strictness of this builder to the provided parameter.
    *
    * <p>This changes how strict the
    * <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259 JSON specification</a> is enforced when parsing or
    * writing JSON. For details on this, refer to {@link JsonReader#setStrictness(Strictness)} and
    * {@link JsonWriter#setStrictness(Strictness)}.</p>
    *
-   * @param strictness the new strictness method of this factory. May not be null.
+   * @param strictness the new strictness mode. May not be {@code null}.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern.
-   * @throws NullPointerException if the provided {@code strictness} is {@code null}.
-   * @see JsonWriter#setStrictness(Strictness) 
+   * @see JsonWriter#setStrictness(Strictness)
    * @see JsonReader#setStrictness(Strictness)
    * @since $next-version$
    */
@@ -708,7 +707,7 @@ public final class GsonBuilder {
   }
 
   /**
-   * Section 2.4 of <a href="http://www.ietf.org/rfc/rfc4627.txt">JSON specification</a> disallows
+   * Section 6 of <a href="https://www.ietf.org/rfc/rfc8259.txt">JSON specification</a> disallows
    * special double values (NaN, Infinity, -Infinity). However,
    * <a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">Javascript
    * specification</a> (see section 4.3.20, 4.3.22, 4.3.23) allows these values as valid Javascript

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -24,6 +24,8 @@ import static com.google.gson.stream.JsonScope.NONEMPTY_ARRAY;
 import static com.google.gson.stream.JsonScope.NONEMPTY_DOCUMENT;
 import static com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
 
+import com.google.gson.FormattingStyle;
+import com.google.gson.Strictness;
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
@@ -36,11 +38,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
-import com.google.gson.FormattingStyle;
-import com.google.gson.Strictness;
-
 /**
- * Writes a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
+ * Writes a JSON (<a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>)
  * encoded value to a stream, one token at a time. The stream includes both
  * literal values (strings, numbers, booleans and nulls) as well as the begin
  * and end delimiters of objects and arrays.
@@ -142,7 +141,7 @@ public class JsonWriter implements Closeable, Flushable {
   private static final Pattern VALID_JSON_NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?(?:[eE][-+]?[0-9]+)?");
 
   /*
-   * From RFC 7159, "All Unicode characters may be placed within the
+   * From RFC 8259, "All Unicode characters may be placed within the
    * quotation marks except for the characters that must be escaped:
    * quotation mark, reverse solidus, and the control characters
    * (U+0000 through U+001F)."
@@ -229,7 +228,7 @@ public class JsonWriter implements Closeable, Flushable {
    * Sets the pretty printing style to be used in the encoded document.
    * No pretty printing if null.
    *
-   * <p>Sets the various attributes to be used in the encoded document. 
+   * <p>Sets the various attributes to be used in the encoded document.
    * For example the indentation string to be repeated for each level of indentation.
    * Or the newline style, to accommodate various OS styles.</p>
    *
@@ -258,7 +257,7 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Set the strictness of this writer.
+   * Sets the strictness of this writer.
    *
    * @param lenient whether this writer should be lenient. If true, the strictness is set to {@link Strictness#LENIENT}.
    *                If false, the strictness is set to {@link Strictness#DEFAULT}.
@@ -269,7 +268,7 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Returns true if this writer has a {@code strictness} value of {@link Strictness#LENIENT}, false otherwise.
+   * Returns true if the {@link Strictness} of this writer is equal to {@link Strictness#LENIENT}.
    *
    * @see JsonWriter#setStrictness(Strictness)
    */
@@ -278,20 +277,23 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Configure how strict this writer is with regard to the syntax rules specified in <a
-   * href="http://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>. By default, {@link Strictness#DEFAULT} is used.
+   * Configures how strict this writer is with regard to the syntax rules specified in <a
+   * href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>. By default, {@link Strictness#DEFAULT} is used.
    *
-   * <ul>
-   *     <li>{@link Strictness#DEFAULT} and {@link Strictness#STRICT}: The behavior of these
-   *     is currently identical. In these strictness modes, the writer only writes JSON in accordance to
-   *     <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>.</li>
-   *     <li>{@link Strictness#LENIENT}: This mode relaxes the behavior of the writer to allow the writing of
-   *     {@link Double#isNaN() NaNs} and {@link Double#isInfinite() infinities}. It also allows you
-   *     writing JSON objects with multiple top level values.</li>
-   * </ul>
+   * <dl>
+   *     <dt>{@link Strictness#STRICT} &amp; {@link Strictness#DEFAULT}</dt>
+   *     <dd>
+   *         The behavior of these is currently identical. In these strictness modes, the writer only writes JSON
+   *         in accordance with <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>.
+   *     </dd>
+   *     <dt>{@link Strictness#LENIENT}</dt>
+   *     <dd>
+   *         This mode relaxes the behavior of the writer to allow the writing of {@link Double#isNaN() NaNs}
+   *         and {@link Double#isInfinite() infinities}. It also allows writing multiple top level values.
+   *     </dd>
+   * </dl>
    *
-   * @param strictness the new strictness of this writer. May not be null.
-   * @throws NullPointerException A null pointer exception is thrown if the provided {@code strictness} is {@code null}.
+   * @param strictness the new strictness of this writer. May not be {@code null}.
    * @since $next-version$
    */
   public final void setStrictness(Strictness strictness) {
@@ -309,7 +311,7 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Configure this writer to emit JSON that's safe for direct inclusion in HTML
+   * Configures this writer to emit JSON that's safe for direct inclusion in HTML
    * and XML documents. This escapes the HTML characters {@code <}, {@code >},
    * {@code &} and {@code =} before writing them to the stream. Without this
    * setting, your XML/HTML encoder should replace these characters with the

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -70,12 +70,9 @@ public final class JsonWriterTest {
   @Test
   public void testSetStrictnessNull() throws IOException {
     JsonWriter jsonWriter = new JsonWriter(new StringWriter());
-    try {
-      assertThrows(NullPointerException.class, () -> jsonWriter.setStrictness(null));
-    } finally {
-      jsonWriter.value(false);
-      jsonWriter.close();
-    }
+    assertThrows(NullPointerException.class, () -> jsonWriter.setStrictness(null));
+    jsonWriter.value(false);
+    jsonWriter.close();
   }
 
   @Test


### PR DESCRIPTION
For simplicity I created this pull request as follow-up for https://github.com/google/gson/pull/2323 to directly address some of the remaining issues.

Main changes:
- Javadoc improvements
  - Make `setStrictness` and `getStrictness` documentation for `JsonReader` and `JsonWriter` more consistent
  - Remove `@throws NullPointerException`; previously no method had documented that, these methods would be the first one to do that
- Refactor `JsonReader.peekKeyword()` to avoid case conversion (see also https://github.com/google/gson/pull/2323#discussion_r1125460186). The code of this pull request here is closer to the original code and avoids any Unicode case conversions since they might lead to accepting input which was previously rejected.

I hope these changes are fine for you, please let me know if there is something I should change (or if you want directly change it yourself after merging.)